### PR TITLE
V6.7+fixes

### DIFF
--- a/sched_events.h
+++ b/sched_events.h
@@ -327,14 +327,22 @@ TRACE_EVENT(sched_cpu_capacity,
 		__field(	unsigned long,	capacity_curr	)
 	),
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6,7,0)
 	unsigned long scale_cpu = rq->cpu_capacity_orig;
-#ifdef CONFIG_ARM64
+ #ifdef CONFIG_ARM64
 	unsigned long scale_freq = arch_scale_freq_capacity(rq->cpu);
+ #else
+	unsigned long scale_freq = SCHED_CAPACITY_SCALE;
+ #endif
 #else
-#warning "arch_scale_freq_capacity() support on non ARM64 platforms needs attention"
-	unsigned long scale_freq = 0;
+ #if (LINUX_VERSION_CODE >= KERNEL_VERSION(6,10,0) && defined(CONFIG_X86)) || defined(CONFIG_ARM64)
+	unsigned long scale_cpu = arch_scale_freq_capacity(rq->cpu);
+	unsigned long scale_freq = arch_scale_freq_capacity(rq->cpu);
+ #else
+	unsigned long scale_cpu = SCHED_CAPACITY_SCALE;
+	unsigned long scale_freq = SCHED_CAPACITY_SCALE;
+ #endif
 #endif
-
 
 	TP_fast_assign(
 		__entry->cpu		= rq->cpu;

--- a/sched_events.h
+++ b/sched_events.h
@@ -192,8 +192,13 @@ TRACE_EVENT(sched_util_est_se,
 		strscpy(__entry->path, path, PATH_SIZE);
 		strscpy(__entry->comm, comm, TASK_COMM_LEN);
 		__entry->pid		= pid;
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6,8,0)
 		__entry->enqueued	= avg->util_est.enqueued;
 		__entry->ewma		= avg->util_est.ewma;
+#else
+		__entry->enqueued	= avg->util_est;
+		__entry->ewma		= avg->util_est;
+#endif
 		__entry->util		= avg->util_avg;
 	),
 
@@ -219,8 +224,13 @@ TRACE_EVENT(sched_util_est_cfs,
 	TP_fast_assign(
 		__entry->cpu		= cpu;
 		strscpy(__entry->path, path, PATH_SIZE);
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6,8,0)
 		__entry->enqueued	= avg->util_est.enqueued;
 		__entry->ewma		= avg->util_est.ewma;
+#else
+		__entry->enqueued	= avg->util_est;
+		__entry->ewma		= avg->util_est;
+#endif
 		__entry->util		= avg->util_avg;
 	),
 

--- a/sched_events.h
+++ b/sched_events.h
@@ -44,7 +44,7 @@ TRACE_EVENT(sched_pelt_cfs,
 
 	TP_fast_assign(
 		__entry->cpu		= cpu;
-		strlcpy(__entry->path, path, PATH_SIZE);
+		strscpy(__entry->path, path, PATH_SIZE);
 		__entry->load		= avg->load_avg;
 		__entry->RBL_LOAD_ENTRY	= avg->RBL_LOAD_MEMBER;
 		__entry->util		= avg->util_avg;
@@ -114,8 +114,8 @@ TRACE_EVENT(sched_pelt_se,
 
 	TP_fast_assign(
 		__entry->cpu		= cpu;
-		strlcpy(__entry->path, path, PATH_SIZE);
-		strlcpy(__entry->comm, comm, TASK_COMM_LEN);
+		strscpy(__entry->path, path, PATH_SIZE);
+		strscpy(__entry->comm, comm, TASK_COMM_LEN);
 		__entry->pid		= pid;
 		__entry->load		= avg->load_avg;
 		__entry->RBL_LOAD_ENTRY	= avg->RBL_LOAD_MEMBER;
@@ -141,7 +141,7 @@ TRACE_EVENT(sched_overutilized,
 
 	TP_fast_assign(
 		__entry->overutilized	= overutilized;
-		strlcpy(__entry->span, span, SPAN_SIZE);
+		strscpy(__entry->span, span, SPAN_SIZE);
 	),
 
 	TP_printk("overutilized=%d span=0x%s",
@@ -189,8 +189,8 @@ TRACE_EVENT(sched_util_est_se,
 
 	TP_fast_assign(
 		__entry->cpu		= cpu;
-		strlcpy(__entry->path, path, PATH_SIZE);
-		strlcpy(__entry->comm, comm, TASK_COMM_LEN);
+		strscpy(__entry->path, path, PATH_SIZE);
+		strscpy(__entry->comm, comm, TASK_COMM_LEN);
 		__entry->pid		= pid;
 		__entry->enqueued	= avg->util_est.enqueued;
 		__entry->ewma		= avg->util_est.ewma;
@@ -218,7 +218,7 @@ TRACE_EVENT(sched_util_est_cfs,
 
 	TP_fast_assign(
 		__entry->cpu		= cpu;
-		strlcpy(__entry->path, path, PATH_SIZE);
+		strscpy(__entry->path, path, PATH_SIZE);
 		__entry->enqueued	= avg->util_est.enqueued;
 		__entry->ewma		= avg->util_est.ewma;
 		__entry->util		= avg->util_avg;

--- a/sched_tp_helpers.h
+++ b/sched_tp_helpers.h
@@ -70,7 +70,7 @@ static inline void cfs_rq_tg_path(struct cfs_rq *cfs_rq, char *path, int len)
 		cgroup_path(cfs_rq->tg->css.cgroup, path, len);
 	else
 #endif
-		strlcpy(path, "(null)", len);
+		strscpy(path, "(null)", len);
 }
 
 /* A cut down version of the original. @p MUST be NULL */
@@ -107,7 +107,7 @@ static inline char *sched_tp_cfs_rq_path(struct cfs_rq *cfs_rq, char *str, int l
 {
 	if (!cfs_rq) {
 		if (str)
-			strlcpy(str, "(null)", len);
+			strscpy(str, "(null)", len);
 		else
 			return NULL;
 	}


### PR DESCRIPTION
Update sched_tp to work with kernels v6.7 and later.   I tried to keep the output strings the same to avoid any issues and just get default values set to something reasonable when they have changed or been removed. 

Note: This should work on arm64 and x86.  Other architectures will likely need more work.